### PR TITLE
fix: re-export Assertion interface

### DIFF
--- a/kubeassert.go
+++ b/kubeassert.go
@@ -15,6 +15,7 @@ import (
 )
 
 type (
+	Assertion           = assertion.Assertion
 	DeploymentAssertion = deployments.DeploymentAssertion
 	NamespaceAssertion  = namespaces.NamespaceAssertion
 	CRDAssertion        = crds.CRDAssertion


### PR DESCRIPTION
Fixes a regression where the Assertion interface is no longer exported from the package.